### PR TITLE
Remove PHP 7.1 from Travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 7.1
   - 7.2
   - 7.3
 


### PR DESCRIPTION
 Laravel 6 requires at least PHP 7.2 so trying to use PHP 7.1 when causes errors like one shown [here](https://travis-ci.org/github/edvinaskrucas/notification/jobs/669758069)